### PR TITLE
WIP : Middleware for stats reporting

### DIFF
--- a/jwt/README.md
+++ b/jwt/README.md
@@ -1,0 +1,81 @@
+# JWT Middleware 
+
+
+This package provides a [goa](http://goa.design) middleware that checks requests for valid
+JWT keys.  If a key is found, it is made available in goa's context for use in the controllers.
+
+It also includes a Token Manager which can be used to create JWT tokens that are valid for use
+with the middleware.  TokenManager also implements the *TokenGen* interfaces of github.com/RangelReale/osin
+so that it can be used to generate tokens for your custom osin-based Oauth2 implementation.
+
+
+## Middleware Usage
+Middleware can be applied at the application or service level in goa.  To use a middleware,
+create an instance of it first, then apply it using the `Use` function of your application or service:
+```go
+	spec := &jwt.Specification{
+		AllowParam:       false,
+		AuthOptions:      false,
+		TTLMinutes:       60,
+		Issuer:           "api.me.com",
+		KeySigningMethod: jwt.RSA256,
+		SigningKeyFunc:   privateKey,
+		ValidationFunc:   pubKey,
+	}
+
+	tm := jwt.NewTokenManager(spec)
+
+	// Generate a test token
+	claims := make(map[string]interface{})
+	claims["custom"] = "hotrod"
+	t, err := tm.Create(claims)
+	fmt.Println(t)
+	fmt.Println(err)
+
+	// Mount "application" controller
+	c := NewApplicationController(service)
+	// Require a valid JWT Token for any routes
+	// on this controller
+	c.Use(jwt.Middleware(spec))
+```
+
+## TokenManager Usage
+TokenManager uses the same specification as the JWT Middleware.  Instantiate it
+with the `NewTokenManager` function: 
+```go
+	spec := &jwt.Specification{
+		AllowParam:       false,
+		AuthOptions:      false,
+		TTLMinutes:       60,
+		Issuer:           "api.me.com",
+		KeySigningMethod: jwt.RSA256,
+		SigningKeyFunc:   privateKey,
+		ValidationFunc:   pubKey,
+	}
+
+	tm := jwt.NewTokenManager(spec)
+
+	// Generate a test token
+	claims := make(map[string]interface{})
+	claims["custom"] = "hotrod"
+	t, err := tm.Create(claims)
+	fmt.Println(t)
+	fmt.Println(err)
+```
+
+Generally you will want to create a custom response type to carry your token:
+
+```go
+
+	type LoginResponse struct {
+		Token string
+		...
+	}
+
+	token, err := tm.Create(...)
+
+	resp:= &LoginResponse{
+		Token = token
+	}
+
+```

--- a/jwt/doc.go
+++ b/jwt/doc.go
@@ -40,5 +40,26 @@ using the same specification used to create the middleware:
 		}
 		return ctx.Respond(200, token) // You'll probably need something different here
 	}
+
+The token manager also implements the osin.AuthorizeTokenGen and AccessTokenGen interfaces (https://github.com/RangelReale/osin)
+which allows you to set osin's AccessTokenGen and AuthorizeTokenGen implementions to an instantiated TokenManager.
+
+	// Do not use this config, provided as an example
+	sconfig := osin.NewServerConfig()
+	sconfig.AllowedAuthorizeTypes = osin.AllowedAuthorizeType{osin.CODE, osin.TOKEN}
+	sconfig.AllowedAccessTypes = osin.AllowedAccessType{
+		osin.AUTHORIZATION_CODE,
+		osin.REFRESH_TOKEN,
+		osin.PASSWORD,
+		osin.CLIENT_CREDENTIALS,
+		osin.ASSERTION,
+	}
+	osinserver := osin.NewServer(sconfig, NewMyOsinStorageImplementation(...))
+	osinserver.AccessTokenGen = tm
+	osinserver.AuthorizeTokenGen = t
+
+Doing this will allow you to use `osin` to manage your backend Oauth2 flow, and use this middleware
+to generate and verify the tokens that are created.
+
 */
 package jwt

--- a/jwt/doc.go
+++ b/jwt/doc.go
@@ -41,25 +41,5 @@ using the same specification used to create the middleware:
 		return ctx.Respond(200, token) // You'll probably need something different here
 	}
 
-The token manager also implements the osin.AuthorizeTokenGen and AccessTokenGen interfaces (https://github.com/RangelReale/osin)
-which allows you to set osin's AccessTokenGen and AuthorizeTokenGen implementions to an instantiated TokenManager.
-
-	// Do not use this config, provided as an example
-	sconfig := osin.NewServerConfig()
-	sconfig.AllowedAuthorizeTypes = osin.AllowedAuthorizeType{osin.CODE, osin.TOKEN}
-	sconfig.AllowedAccessTypes = osin.AllowedAccessType{
-		osin.AUTHORIZATION_CODE,
-		osin.REFRESH_TOKEN,
-		osin.PASSWORD,
-		osin.CLIENT_CREDENTIALS,
-		osin.ASSERTION,
-	}
-	osinserver := osin.NewServer(sconfig, NewMyOsinStorageImplementation(...))
-	osinserver.AccessTokenGen = tm
-	osinserver.AuthorizeTokenGen = t
-
-Doing this will allow you to use `osin` to manage your backend Oauth2 flow, and use this middleware
-to generate and verify the tokens that are created.
-
 */
 package jwt

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -89,6 +89,9 @@ type Specification struct {
 	AuthOptions bool
 	// TTLMinutes is the TTL for tokens that are generated
 	TTLMinutes int
+	// RefreshTTLMinutes is the TTL for refresh tokens that are generated
+	// and should generally be much longer than TTLMinutes
+	RefreshTTLMinutes int
 	// Issuer is the name of the issuer that will be inserted into the
 	// generated token's claims
 	Issuer string

--- a/jwt/token.go
+++ b/jwt/token.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/RangelReale/osin"
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -57,76 +56,4 @@ func (tm *TokenManager) Create(claims map[string]interface{}) (string, error) {
 	}
 	return t.SignedString(bytes)
 
-}
-
-// GenerateAuthorizeToken satisfies the AuthorizeTokenGen interface for RangelReale/osin
-// So that osin may be used for storage and token generation.  GenerateAuthorizeToken
-// returns an access token
-func (tm *TokenManager) GenerateAuthorizeToken(data *osin.AuthorizeData) (string, error) {
-
-	t := jwt.New(jwt.GetSigningMethod(signingmethods[tm.spec.KeySigningMethod]))
-	if tm.spec.Issuer != "" {
-		t.Claims["iss"] = tm.spec.Issuer
-	}
-
-	for k, v := range tm.spec.CommonClaims {
-		t.Claims[k] = v
-	}
-	t.Claims["scopes"] = data.Scope
-	// set issued at time
-	t.Claims["iat"] = data.CreatedAt.Unix()
-	// set the expire time
-	t.Claims["exp"] = time.Now().Add(time.Second * time.Duration(data.ExpiresIn)).Unix()
-	bytes, err := tm.spec.SigningKeyFunc()
-	if err != nil {
-		return "", fmt.Errorf("Error retrieving Signing Key: %v", err)
-	}
-	return t.SignedString(bytes)
-
-}
-
-// GenerateAccessToken satisfies the AuthorizeTokenGen interface for RangelReale/osin
-// So that osin may be used for storage and token generation.  GenerateAccessToken
-// creates both an access token and a refresh token.
-func (tm *TokenManager) GenerateAccessToken(data *osin.AccessData, generaterefresh bool) (accesstoken string, refreshtoken string, err error) {
-	t := jwt.New(jwt.GetSigningMethod(signingmethods[tm.spec.KeySigningMethod]))
-	if tm.spec.Issuer != "" {
-		t.Claims["iss"] = tm.spec.Issuer
-	}
-
-	for k, v := range tm.spec.CommonClaims {
-		t.Claims[k] = v
-	}
-	t.Claims["scopes"] = data.Scope
-	// set issued at time
-	t.Claims["iat"] = data.CreatedAt.Unix()
-	// set the expire time
-	t.Claims["exp"] = time.Now().Add(time.Second * time.Duration(data.ExpiresIn)).Unix()
-	bytes, err := tm.spec.SigningKeyFunc()
-	if err != nil {
-		return "", "", fmt.Errorf("Error retrieving Signing Key: %v", err)
-	}
-	accesstoken, err = t.SignedString(bytes)
-	if err != nil {
-		return "", "", err
-	}
-	r := jwt.New(jwt.GetSigningMethod(signingmethods[tm.spec.KeySigningMethod]))
-	if tm.spec.Issuer != "" {
-		r.Claims["iss"] = tm.spec.Issuer
-	}
-
-	for k, v := range tm.spec.CommonClaims {
-		r.Claims[k] = v
-	}
-	r.Claims["scopes"] = data.Scope
-	// set issued at time
-	r.Claims["iat"] = data.CreatedAt.Unix()
-	// set the expire time
-	r.Claims["exp"] = time.Now().Add(time.Minute * time.Duration(tm.spec.RefreshTTLMinutes)).Unix()
-	bytes, err = tm.spec.SigningKeyFunc()
-	if err != nil {
-		return "", "", fmt.Errorf("Error retrieving Signing Key: %v", err)
-	}
-	refreshtoken, err = r.SignedString(bytes)
-	return accesstoken, refreshtoken, err
 }

--- a/jwt/token.go
+++ b/jwt/token.go
@@ -4,9 +4,16 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/RangelReale/osin"
 	"github.com/dgrijalva/jwt-go"
 )
 
+const (
+	ttldefault        = 5
+	refreshttldefault = 1440 // default to one day
+)
+
+// TokenManager provides for the creation of access and refresh JWT Tokens
 type TokenManager struct {
 	spec *Specification
 }
@@ -16,7 +23,10 @@ type TokenManager struct {
 // Middleware() to ensure your tokens are compatible.
 func NewTokenManager(spec *Specification) *TokenManager {
 	if spec.TTLMinutes == 0 {
-		spec.TTLMinutes = 5
+		spec.TTLMinutes = ttldefault
+	}
+	if spec.RefreshTTLMinutes == 0 {
+		spec.RefreshTTLMinutes = refreshttldefault
 	}
 	return &TokenManager{spec: spec}
 }
@@ -47,4 +57,76 @@ func (tm *TokenManager) Create(claims map[string]interface{}) (string, error) {
 	}
 	return t.SignedString(bytes)
 
+}
+
+// GenerateAuthorizeToken satisfies the AuthorizeTokenGen interface for RangelReale/osin
+// So that osin may be used for storage and token generation.  GenerateAuthorizeToken
+// returns an access token
+func (tm *TokenManager) GenerateAuthorizeToken(data *osin.AuthorizeData) (string, error) {
+
+	t := jwt.New(jwt.GetSigningMethod(signingmethods[tm.spec.KeySigningMethod]))
+	if tm.spec.Issuer != "" {
+		t.Claims["iss"] = tm.spec.Issuer
+	}
+
+	for k, v := range tm.spec.CommonClaims {
+		t.Claims[k] = v
+	}
+	t.Claims["scopes"] = data.Scope
+	// set issued at time
+	t.Claims["iat"] = data.CreatedAt.Unix()
+	// set the expire time
+	t.Claims["exp"] = time.Now().Add(time.Second * time.Duration(data.ExpiresIn)).Unix()
+	bytes, err := tm.spec.SigningKeyFunc()
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving Signing Key: %v", err)
+	}
+	return t.SignedString(bytes)
+
+}
+
+// GenerateAccessToken satisfies the AuthorizeTokenGen interface for RangelReale/osin
+// So that osin may be used for storage and token generation.  GenerateAccessToken
+// creates both an access token and a refresh token.
+func (tm *TokenManager) GenerateAccessToken(data *osin.AccessData, generaterefresh bool) (accesstoken string, refreshtoken string, err error) {
+	t := jwt.New(jwt.GetSigningMethod(signingmethods[tm.spec.KeySigningMethod]))
+	if tm.spec.Issuer != "" {
+		t.Claims["iss"] = tm.spec.Issuer
+	}
+
+	for k, v := range tm.spec.CommonClaims {
+		t.Claims[k] = v
+	}
+	t.Claims["scopes"] = data.Scope
+	// set issued at time
+	t.Claims["iat"] = data.CreatedAt.Unix()
+	// set the expire time
+	t.Claims["exp"] = time.Now().Add(time.Second * time.Duration(data.ExpiresIn)).Unix()
+	bytes, err := tm.spec.SigningKeyFunc()
+	if err != nil {
+		return "", "", fmt.Errorf("Error retrieving Signing Key: %v", err)
+	}
+	accesstoken, err = t.SignedString(bytes)
+	if err != nil {
+		return "", "", err
+	}
+	r := jwt.New(jwt.GetSigningMethod(signingmethods[tm.spec.KeySigningMethod]))
+	if tm.spec.Issuer != "" {
+		r.Claims["iss"] = tm.spec.Issuer
+	}
+
+	for k, v := range tm.spec.CommonClaims {
+		r.Claims[k] = v
+	}
+	r.Claims["scopes"] = data.Scope
+	// set issued at time
+	r.Claims["iat"] = data.CreatedAt.Unix()
+	// set the expire time
+	r.Claims["exp"] = time.Now().Add(time.Minute * time.Duration(tm.spec.RefreshTTLMinutes)).Unix()
+	bytes, err = tm.spec.SigningKeyFunc()
+	if err != nil {
+		return "", "", fmt.Errorf("Error retrieving Signing Key: %v", err)
+	}
+	refreshtoken, err = r.SignedString(bytes)
+	return accesstoken, refreshtoken, err
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -1,0 +1,27 @@
+package stats
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/raphael/goa"
+)
+
+// Reporter is a middleware that reports statistics to any sink
+// supported by github.com/armon/go-metrics, which currently
+// includes statsd, prometheus and others
+func Reporter(sink metrics.MetricSink) goa.Middleware {
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx *goa.Context) error {
+			start := time.Now()
+			err := h(ctx)
+			r := ctx.Request()
+			key := fmt.Sprintf("%s_%s", r.Method, r.URL.String())
+			metrics.MeasureSince([]string{key}, start)
+			return err
+		}
+
+	}
+
+}


### PR DESCRIPTION
This change adds the osin.Access- and osin.AuthorizeTokenGen implementations so that the middleware can be used by osin to generate tokens.  This allows you to generate tokens with the same exact specifications that you're using in the middleware when you're checking tokens.